### PR TITLE
Dberger v2v transformation mapping validation on vm name

### DIFF
--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -142,11 +142,13 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def validate_vm_name_rhevm(vm)
-    vm.name =~ /^[\\p{L}0-9._-]*$/
+    # Regexp from oVirt code: frontend/webadmin/modules/uicommonweb/src/main/java/org/ovirt/engine/ui/uicommonweb/validation/BaseI18NValidation.java
+    vm.name =~ /^[\p{L}0-9._-]*$/
   end
 
   def validate_vm_name_openstack(vm)
-    true
+    # Regexp decided after discussion with Bernard Cafarelli
+    vm.name =~ /^[[:graph:]\s]*$/
   end
 
   class VmMigrateStruct < MiqHashStruct

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -148,7 +148,7 @@ class TransformationMapping::VmMigrationValidator
 
   def validate_vm_name_openstack(vm)
     # Regexp decided after discussion with Bernard Cafarelli
-    vm.name =~ /^[[:graph:]\s]*$/
+    vm.name =~ /^[[:graph:]\s]+$/
   end
 
   class VmMigrateStruct < MiqHashStruct

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -138,7 +138,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def validate_vm_name(vm)
-    send("validate_vm_name_#{destination_cluster(vm).emstype}", vm) ? VM_VALID : VM_UNSUPPORTED_NAME
+    send("validate_vm_name_#{destination_cluster(vm).ext_management_system.emstype}", vm) ? VM_VALID : VM_UNSUPPORTED_NAME
   end
 
   def validate_vm_name_rhevm(vm)

--- a/app/models/transformation_mapping/vm_migration_validator.rb
+++ b/app/models/transformation_mapping/vm_migration_validator.rb
@@ -134,7 +134,7 @@ class TransformationMapping::VmMigrationValidator
   end
 
   def destination_cluster(vm)
-    @mapping.transformation_mapping_items.find(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
+    @mapping.transformation_mapping_items.find_by(:source_type => 'EmsCluster', :source_id => vm.ems_cluster.id).destination
   end
 
   def validate_vm_name(vm)

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -1,6 +1,7 @@
-RSpec.describe TransformationMapping, :v2v do
+describe TransformationMapping do
+  let(:ems) { FactoryBot.create(:ems_redhat) }
   let(:src) { FactoryBot.create(:ems_cluster) }
-  let(:dst) { FactoryBot.create(:ems_cluster) }
+  let(:dst) { FactoryBot.create(:ems_cluster, :ext_management_system => ems) }
   let(:vm)  { FactoryBot.create(:vm_vmware, :ems_cluster => src) }
 
   let(:mapping) do

--- a/spec/models/transformation_mapping_spec.rb
+++ b/spec/models/transformation_mapping_spec.rb
@@ -68,7 +68,7 @@ describe TransformationMapping do
 
         it 'if VM has an invalid name in openstack' do
           vm_for_openstack.storages << FactoryBot.create(:storage)
-          name = "\u1F4A9 poo"
+          name = 7.chr # beep, non-printable
           FactoryBot.create(:vm_vmware, :name => name, :ems_cluster => src_openstack, :ext_management_system => ems_openstack)
           result = openstack_mapping.search_vms_and_validate(['name' => name])
           expect(result['invalid'].first.reason).to eq(TransformationMapping::VmMigrationValidator::VM_UNSUPPORTED_NAME)


### PR DESCRIPTION
This PR looks terrible because I rebased, but just look at the last commits at https://github.com/fdupont-redhat/manageiq/commit/a5ec67dbd63cf10b7f24fb82e7cbca91ca236904 and https://github.com/fdupont-redhat/manageiq/pull/1/commits/d0f2473ad8e865d783cef33a738d935a1e0f094f.

The short version is that I added some VM validation specs. However, for openstack I found an issue. The current regex won't work because it will essentially match anything since it's looking for "zero or more". Well, that's everything, including an empty string, so I changed the '*' to a '+', so at least 1 character must be present.

However, even with that change, it still seems to match just about everything, including unicode characters. You mention "special" characters, but I'm not sure what you mean by that. I need to understand the openstack rules for vm names better before I can fix it and/or test it properly. It looks like there was some discussion in 2014 about loosening the naming rules, but I'm not sure what came of it.

Anyway, this should get you most of the way there.

Update: wondering if we really need the openstack validation since only non-printable characters would be invalid now: https://review.opendev.org/#/c/119741/

Update2: I updated the openstack spec to validate against a non-printable character, which I think is about the only thing openstack doesn't allow now.